### PR TITLE
Log event when fail publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ gradle-app.setting
 .settings
 *.class
 .factorypath
+.idea

--- a/plugin/src/main/java/dev/regadas/trino/pubsub/listener/PubSubEventListener.java
+++ b/plugin/src/main/java/dev/regadas/trino/pubsub/listener/PubSubEventListener.java
@@ -10,7 +10,6 @@ import com.google.cloud.pubsub.v1.Publisher;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Message;
-import com.google.protobuf.util.JsonFormat;
 import com.google.pubsub.v1.PubsubMessage;
 
 import dev.regadas.trino.pubsub.listener.Encoder.MessageEncoder;
@@ -94,7 +93,12 @@ public final class PubSubEventListener implements EventListener, AutoCloseable {
                         }
 
                         public void onFailure(Throwable t) {
-                            LOG.log(Level.SEVERE, "Failed to publish event", t);
+                            LOG.log(
+                                    Level.SEVERE,
+                                    "Failed to publish event, error: "
+                                            + t.getMessage()
+                                            + " , event: "
+                                            + message.getData().toStringUtf8());
                         }
                     },
                     MoreExecutors.directExecutor());


### PR DESCRIPTION
When publish event fails, the stacktrace is not much of help. Add event data in log to help debug.