### PR TITLE
Add mbean metrics

### DIFF
--- a/plugin/src/main/java/dev/regadas/trino/pubsub/listener/PubSubEventListener.java
+++ b/plugin/src/main/java/dev/regadas/trino/pubsub/listener/PubSubEventListener.java
@@ -42,21 +42,21 @@ public final class PubSubEventListener implements EventListener, AutoCloseable {
     @Override
     public void queryCreated(QueryCreatedEvent event) {
         if (config.trackQueryCreatedEvent()) {
-            publish(SchemaHelpers.from(event), pubSubInfo.queryCreated());
+            publish(SchemaHelpers.from(event), pubSubInfo.getQueryCreated());
         }
     }
 
     @Override
     public void queryCompleted(QueryCompletedEvent event) {
         if (config.trackQueryCompletedEvent()) {
-            publish(SchemaHelpers.from(event), pubSubInfo.queryCompleted());
+            publish(SchemaHelpers.from(event), pubSubInfo.getQueryCompleted());
         }
     }
 
     @Override
     public void splitCompleted(SplitCompletedEvent event) {
         if (config.trackSplitCompletedEvent()) {
-            publish(SchemaHelpers.from(event), pubSubInfo.splitCompleted());
+            publish(SchemaHelpers.from(event), pubSubInfo.getSplitCompleted());
         }
     }
 

--- a/plugin/src/main/java/dev/regadas/trino/pubsub/listener/PubSubEventListener.java
+++ b/plugin/src/main/java/dev/regadas/trino/pubsub/listener/PubSubEventListener.java
@@ -84,8 +84,8 @@ public final class PubSubEventListener implements EventListener, AutoCloseable {
     @Override
     public void close() {
         try {
-            publisher.shutdown();
-        } catch (InterruptedException e) {
+            publisher.close();
+        } catch (Exception e) {
             LOG.log(Level.SEVERE, "Failed to shutdown publisher", e);
         }
     }

--- a/plugin/src/main/java/dev/regadas/trino/pubsub/listener/PubSubEventListener.java
+++ b/plugin/src/main/java/dev/regadas/trino/pubsub/listener/PubSubEventListener.java
@@ -67,7 +67,7 @@ public final class PubSubEventListener implements EventListener, AutoCloseable {
 
             future.whenComplete(
                     (id, t) -> {
-                        if (t != null) {
+                        if (t == null) {
                             counters.successful().incrementAndGet();
                             LOG.log(Level.ALL, "published event with id: " + id);
                         } else {

--- a/plugin/src/main/java/dev/regadas/trino/pubsub/listener/PubSubEventListenerFactory.java
+++ b/plugin/src/main/java/dev/regadas/trino/pubsub/listener/PubSubEventListenerFactory.java
@@ -1,8 +1,8 @@
 package dev.regadas.trino.pubsub.listener;
 
+import dev.regadas.trino.pubsub.listener.metrics.MBeanRegister;
 import io.trino.spi.eventlistener.EventListener;
 import io.trino.spi.eventlistener.EventListenerFactory;
-
 import java.io.IOException;
 import java.util.Map;
 
@@ -16,8 +16,12 @@ public final class PubSubEventListenerFactory implements EventListenerFactory {
     @Override
     public EventListener create(Map<String, String> config) {
         var listenerConfig = PubSubEventListenerConfig.create(config);
+
         try {
-            return PubSubEventListener.create(listenerConfig);
+            PubSubEventListener eventListener = PubSubEventListener.create(listenerConfig);
+            MBeanRegister.registerMBean(config, eventListener.getPubSubInfo());
+
+            return eventListener;
         } catch (IOException e) {
             throw new RuntimeException("Failed to create PubSubEventListener", e);
         }

--- a/plugin/src/main/java/dev/regadas/trino/pubsub/listener/metrics/MBeanRegister.java
+++ b/plugin/src/main/java/dev/regadas/trino/pubsub/listener/metrics/MBeanRegister.java
@@ -22,11 +22,7 @@ public class MBeanRegister {
         try {
             var jmxDomainBase = config.getOrDefault(CONFIG_KEY, DEFAULT_DOMAIN_NAME);
             var platformMBeanServer = ManagementFactory.getPlatformMBeanServer();
-            var objectName =
-                    new ObjectName(
-                            "%s.PubSubEventListener:projectId=%s,topicId=%s"
-                                    .formatted(
-                                            jmxDomainBase, info.getProjectId(), info.getTopicId()));
+            var objectName = new ObjectName(jmxDomainBase + ".listener:name=PubSubEventListener");
             platformMBeanServer.registerMBean(info, objectName);
         } catch (MalformedObjectNameException
                 | NotCompliantMBeanException

--- a/plugin/src/main/java/dev/regadas/trino/pubsub/listener/metrics/MBeanRegister.java
+++ b/plugin/src/main/java/dev/regadas/trino/pubsub/listener/metrics/MBeanRegister.java
@@ -1,0 +1,38 @@
+package dev.regadas.trino.pubsub.listener.metrics;
+
+import java.lang.management.ManagementFactory;
+import java.util.Map;
+import javax.management.InstanceAlreadyExistsException;
+import javax.management.MBeanRegistrationException;
+import javax.management.MalformedObjectNameException;
+import javax.management.NotCompliantMBeanException;
+import javax.management.ObjectName;
+
+public class MBeanRegister {
+
+    // Same as
+    // https://github.com/trinodb/trino/blob/f680380ae1adbb3c47ee6953873197a0c82dc308/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/jmx/ObjectNameGeneratorConfig.java#L27
+    private static final String CONFIG_KEY = "jmx.base-name";
+
+    // Same as
+    // https://github.com/trinodb/trino/blob/f680380ae1adbb3c47ee6953873197a0c82dc308/core/trino-main/src/main/java/io/trino/server/JmxNamingConfig.java#L20
+    private static final String DEFAULT_DOMAIN_NAME = "trino";
+
+    public static void registerMBean(Map<String, String> config, PubSubInfoMBean info) {
+        try {
+            var jmxDomainBase = config.getOrDefault(CONFIG_KEY, DEFAULT_DOMAIN_NAME);
+            var platformMBeanServer = ManagementFactory.getPlatformMBeanServer();
+            var objectName =
+                    new ObjectName(
+                            "%s.PubSubEventListener:projectId=%s,topicId=%s"
+                                    .formatted(
+                                            jmxDomainBase, info.getProjectId(), info.getTopicId()));
+            platformMBeanServer.registerMBean(info, objectName);
+        } catch (MalformedObjectNameException
+                | NotCompliantMBeanException
+                | InstanceAlreadyExistsException
+                | MBeanRegistrationException e) {
+            throw new RuntimeException("Failed to register MBean for PubSubEventListener", e);
+        }
+    }
+}

--- a/plugin/src/main/java/dev/regadas/trino/pubsub/listener/metrics/PubSubCounters.java
+++ b/plugin/src/main/java/dev/regadas/trino/pubsub/listener/metrics/PubSubCounters.java
@@ -1,0 +1,18 @@
+package dev.regadas.trino.pubsub.listener.metrics;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+public record PubSubCounters(AtomicLong attempts, AtomicLong successful, AtomicLong failure) {
+
+    public PubSubCounters() {
+        this(new AtomicLong(), new AtomicLong(), new AtomicLong());
+    }
+
+    public PubSubCounters {
+        requireNonNull(attempts, "attempts is null");
+        requireNonNull(successful, "successful is null");
+        requireNonNull(failure, "failure is null");
+    }
+}

--- a/plugin/src/main/java/dev/regadas/trino/pubsub/listener/metrics/PubSubInfo.java
+++ b/plugin/src/main/java/dev/regadas/trino/pubsub/listener/metrics/PubSubInfo.java
@@ -1,0 +1,79 @@
+package dev.regadas.trino.pubsub.listener.metrics;
+
+import static java.util.Objects.*;
+
+public record PubSubInfo(
+        String projectId,
+        String topicId,
+        PubSubCounters queryCreated,
+        PubSubCounters queryCompleted,
+        PubSubCounters splitCompleted)
+        implements PubSubInfoMBean {
+
+    public PubSubInfo(String projectId, String topicId) {
+        this(projectId, topicId, new PubSubCounters(), new PubSubCounters(), new PubSubCounters());
+    }
+
+    public PubSubInfo {
+        requireNonNull(projectId, "projectId is null");
+        requireNonNull(topicId, "topicId is null");
+        requireNonNull(queryCreated, "queryCreated is null");
+        requireNonNull(queryCompleted, "queryCompleted is null");
+        requireNonNull(splitCompleted, "splitCompleted is null");
+    }
+
+    @Override
+    public String getProjectId() {
+        return this.projectId;
+    }
+
+    @Override
+    public String getTopicId() {
+        return this.topicId;
+    }
+
+    @Override
+    public Long getQueryCreatedPublicationAttempts() {
+        return queryCreated.attempts().get();
+    }
+
+    @Override
+    public Long getQueryCreatedPublishedSuccessfully() {
+        return queryCreated.successful().get();
+    }
+
+    @Override
+    public Long getQueryCreatedPublicationFailed() {
+        return queryCreated.failure().get();
+    }
+
+    @Override
+    public Long getQueryCompletedPublicationAttempts() {
+        return queryCompleted.attempts().get();
+    }
+
+    @Override
+    public Long getQueryCompletedPublishedSuccessfully() {
+        return queryCompleted.successful().get();
+    }
+
+    @Override
+    public Long getQueryCompletedPublicationFailed() {
+        return queryCompleted.failure().get();
+    }
+
+    @Override
+    public Long getSplitCompletedPublicationAttempts() {
+        return splitCompleted.attempts().get();
+    }
+
+    @Override
+    public Long getSplitCompletedPublishedSuccessfully() {
+        return splitCompleted.successful().get();
+    }
+
+    @Override
+    public Long getSplitCompletedPublicationFailed() {
+        return splitCompleted.failure().get();
+    }
+}

--- a/plugin/src/main/java/dev/regadas/trino/pubsub/listener/metrics/PubSubInfo.java
+++ b/plugin/src/main/java/dev/regadas/trino/pubsub/listener/metrics/PubSubInfo.java
@@ -1,6 +1,6 @@
 package dev.regadas.trino.pubsub.listener.metrics;
 
-import static java.util.Objects.*;
+import static java.util.Objects.requireNonNull;
 
 public class PubSubInfo implements PubSubInfoMBean {
 

--- a/plugin/src/main/java/dev/regadas/trino/pubsub/listener/metrics/PubSubInfo.java
+++ b/plugin/src/main/java/dev/regadas/trino/pubsub/listener/metrics/PubSubInfo.java
@@ -2,24 +2,20 @@ package dev.regadas.trino.pubsub.listener.metrics;
 
 import static java.util.Objects.*;
 
-public record PubSubInfo(
-        String projectId,
-        String topicId,
-        PubSubCounters queryCreated,
-        PubSubCounters queryCompleted,
-        PubSubCounters splitCompleted)
-        implements PubSubInfoMBean {
+public class PubSubInfo implements PubSubInfoMBean {
+
+    private final String projectId;
+    private final String topicId;
+    private final PubSubCounters queryCreated;
+    private final PubSubCounters queryCompleted;
+    private final PubSubCounters splitCompleted;
 
     public PubSubInfo(String projectId, String topicId) {
-        this(projectId, topicId, new PubSubCounters(), new PubSubCounters(), new PubSubCounters());
-    }
-
-    public PubSubInfo {
-        requireNonNull(projectId, "projectId is null");
-        requireNonNull(topicId, "topicId is null");
-        requireNonNull(queryCreated, "queryCreated is null");
-        requireNonNull(queryCompleted, "queryCompleted is null");
-        requireNonNull(splitCompleted, "splitCompleted is null");
+        this.projectId = requireNonNull(projectId, "projectId is null");
+        this.topicId = requireNonNull(topicId, "topicId is null");
+        this.queryCreated = new PubSubCounters();
+        this.queryCompleted = new PubSubCounters();
+        this.splitCompleted = new PubSubCounters();
     }
 
     @Override
@@ -30,6 +26,18 @@ public record PubSubInfo(
     @Override
     public String getTopicId() {
         return this.topicId;
+    }
+
+    public PubSubCounters getQueryCreated() {
+        return queryCreated;
+    }
+
+    public PubSubCounters getQueryCompleted() {
+        return queryCompleted;
+    }
+
+    public PubSubCounters getSplitCompleted() {
+        return splitCompleted;
     }
 
     @Override

--- a/plugin/src/main/java/dev/regadas/trino/pubsub/listener/metrics/PubSubInfoMBean.java
+++ b/plugin/src/main/java/dev/regadas/trino/pubsub/listener/metrics/PubSubInfoMBean.java
@@ -1,0 +1,25 @@
+package dev.regadas.trino.pubsub.listener.metrics;
+
+public interface PubSubInfoMBean {
+    String getProjectId();
+
+    String getTopicId();
+
+    Long getQueryCreatedPublicationAttempts();
+
+    Long getQueryCreatedPublishedSuccessfully();
+
+    Long getQueryCreatedPublicationFailed();
+
+    Long getQueryCompletedPublicationAttempts();
+
+    Long getQueryCompletedPublishedSuccessfully();
+
+    Long getQueryCompletedPublicationFailed();
+
+    Long getSplitCompletedPublicationAttempts();
+
+    Long getSplitCompletedPublishedSuccessfully();
+
+    Long getSplitCompletedPublicationFailed();
+}

--- a/plugin/src/main/java/dev/regadas/trino/pubsub/listener/pubsub/PubSubPublisher.java
+++ b/plugin/src/main/java/dev/regadas/trino/pubsub/listener/pubsub/PubSubPublisher.java
@@ -66,7 +66,7 @@ public class PubSubPublisher implements Publisher {
     }
 
     @Override
-    public void shutdown() throws InterruptedException {
+    public void close() throws InterruptedException {
         publisher.shutdown();
         publisher.awaitTermination(60, TimeUnit.SECONDS);
     }

--- a/plugin/src/main/java/dev/regadas/trino/pubsub/listener/pubsub/PubSubPublisher.java
+++ b/plugin/src/main/java/dev/regadas/trino/pubsub/listener/pubsub/PubSubPublisher.java
@@ -1,0 +1,92 @@
+package dev.regadas.trino.pubsub.listener.pubsub;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutureCallback;
+import com.google.api.core.ApiFutures;
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Message;
+import com.google.pubsub.v1.PubsubMessage;
+import com.google.pubsub.v1.TopicName;
+import dev.regadas.trino.pubsub.listener.Encoder;
+import dev.regadas.trino.pubsub.listener.Encoder.Encoding;
+import dev.regadas.trino.pubsub.listener.Encoder.MessageEncoder;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+
+public class PubSubPublisher implements Publisher {
+    private final com.google.cloud.pubsub.v1.Publisher publisher;
+    private final Encoder<Message> encoder;
+
+    public PubSubPublisher(com.google.cloud.pubsub.v1.Publisher publisher, MessageEncoder encoder) {
+        this.publisher = requireNonNull(publisher, "publisher is null");
+        this.encoder = requireNonNull(encoder, "encoder is null");
+    }
+
+    public static PubSubPublisher create(
+            String projectId,
+            String topicName,
+            Encoding encoding,
+            @Nullable String credentialsFilePath)
+            throws IOException {
+        var credentials =
+                (credentialsFilePath == null)
+                        ? GoogleCredentials.getApplicationDefault()
+                        : GoogleCredentials.fromStream(new FileInputStream(credentialsFilePath));
+
+        var publisher =
+                com.google.cloud.pubsub.v1.Publisher.newBuilder(TopicName.of(projectId, topicName))
+                        .setCredentialsProvider(FixedCredentialsProvider.create(credentials))
+                        .setEnableCompression(true)
+                        .build();
+
+        var encoder = MessageEncoder.create(encoding);
+        return new PubSubPublisher(publisher, encoder);
+    }
+
+    @Override
+    public CompletableFuture<String> publish(Message message) {
+        try {
+            var data = ByteString.copyFrom(encoder.encode(message));
+            var pubSubMessage = PubsubMessage.newBuilder().setData(data).build();
+
+            var future = publisher.publish(pubSubMessage);
+
+            return toCompletableFuture(future);
+        } catch (Exception e) {
+            return CompletableFuture.failedFuture(e);
+        }
+    }
+
+    @Override
+    public void shutdown() throws InterruptedException {
+        publisher.shutdown();
+        publisher.awaitTermination(60, TimeUnit.SECONDS);
+    }
+
+    private <T> CompletableFuture<T> toCompletableFuture(ApiFuture<T> apiFuture) {
+        var cf = new CompletableFuture<T>();
+        ApiFutures.addCallback(
+                apiFuture,
+                new ApiFutureCallback<>() {
+                    @Override
+                    public void onFailure(Throwable t) {
+                        cf.completeExceptionally(t);
+                    }
+
+                    @Override
+                    public void onSuccess(T result) {
+                        cf.complete(result);
+                    }
+                },
+                MoreExecutors.directExecutor());
+        return cf;
+    }
+}

--- a/plugin/src/main/java/dev/regadas/trino/pubsub/listener/pubsub/Publisher.java
+++ b/plugin/src/main/java/dev/regadas/trino/pubsub/listener/pubsub/Publisher.java
@@ -3,8 +3,6 @@ package dev.regadas.trino.pubsub.listener.pubsub;
 import com.google.protobuf.Message;
 import java.util.concurrent.CompletableFuture;
 
-public interface Publisher {
+public interface Publisher extends AutoCloseable {
     CompletableFuture<String> publish(Message message);
-
-    void shutdown() throws InterruptedException;
 }

--- a/plugin/src/main/java/dev/regadas/trino/pubsub/listener/pubsub/Publisher.java
+++ b/plugin/src/main/java/dev/regadas/trino/pubsub/listener/pubsub/Publisher.java
@@ -1,0 +1,10 @@
+package dev.regadas.trino.pubsub.listener.pubsub;
+
+import com.google.protobuf.Message;
+import java.util.concurrent.CompletableFuture;
+
+public interface Publisher {
+    CompletableFuture<String> publish(Message message);
+
+    void shutdown() throws InterruptedException;
+}

--- a/plugin/src/test/java/dev/regadas/trino/pubsub/listener/PubSubEventListenerTest.java
+++ b/plugin/src/test/java/dev/regadas/trino/pubsub/listener/PubSubEventListenerTest.java
@@ -1,0 +1,230 @@
+package dev.regadas.trino.pubsub.listener;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
+import com.google.protobuf.Message;
+import dev.regadas.trino.pubsub.listener.Encoder.Encoding;
+import dev.regadas.trino.pubsub.listener.proto.Schema;
+import dev.regadas.trino.pubsub.listener.pubsub.Publisher;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.concurrent.CompletableFuture;
+import org.hamcrest.Matcher;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@SuppressWarnings("ALL")
+class PubSubEventListenerTest {
+
+    @ParameterizedTest
+    @CsvSource(
+            textBlock =
+                    """
+      # trackEvent,  pubResult, pubThrow, expAttempt, expSuccess, expFail
+      true,          true,      true,     1,          0,          1
+      true,          true,      false,    1,          1,          0
+      true,          false,     true,     1,          0,          1
+      true,          false,     false,    1,          0,          1
+      false,         true,      true,     0,          0,          0
+      false,         true,      false,    0,          0,          0
+      false,         false,     true,     0,          0,          0
+      false,         false,     false,    0,          0,          0
+      """)
+    void testCounterForQueryCreated(
+            boolean trackEvent,
+            boolean pubResult,
+            boolean pubThrow,
+            long expAttempt,
+            long expSuccess,
+            long expFail)
+            throws InterruptedException {
+        var publisher = new TestPublisher(pubResult, true, pubThrow);
+        var config =
+                new PubSubEventListenerConfig(
+                        trackEvent, false, false, "", "", null, Encoding.JSON);
+        var eventListener = new PubSubEventListener(config, publisher);
+
+        eventListener.queryCreated(TestData.FULL_QUERY_CREATED_EVENT);
+
+        assertThatEventually(
+                eventListener.getPubSubInfo().queryCreated().attempts().get(), equalTo(expAttempt));
+        assertThatEventually(
+                eventListener.getPubSubInfo().queryCreated().successful().get(),
+                equalTo(expSuccess));
+        assertThatEventually(
+                eventListener.getPubSubInfo().queryCreated().failure().get(), equalTo(expFail));
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+            textBlock =
+                    """
+      # trackEvent,  pubResult, pubThrow, expAttempt, expSuccess, expFail
+      true,          true,      true,     1,          0,          1
+      true,          true,      false,    1,          1,          0
+      true,          false,     true,     1,          0,          1
+      true,          false,     false,    1,          0,          1
+      false,         true,      true,     0,          0,          0
+      false,         true,      false,    0,          0,          0
+      false,         false,     true,     0,          0,          0
+      false,         false,     false,    0,          0,          0
+      """)
+    void testCounterForQueryCompleted(
+            boolean trackEvent,
+            boolean pubResult,
+            boolean pubThrow,
+            long expAttempt,
+            long expSuccess,
+            long expFail)
+            throws InterruptedException {
+        var publisher = new TestPublisher(pubResult, true, pubThrow);
+        var config =
+                new PubSubEventListenerConfig(
+                        false, trackEvent, false, "", "", null, Encoding.JSON);
+        var eventListener = new PubSubEventListener(config, publisher);
+
+        eventListener.queryCompleted(TestData.FULL_QUERY_COMPLETED_EVENT);
+
+        assertThatEventually(
+                eventListener.getPubSubInfo().queryCompleted().attempts().get(),
+                equalTo(expAttempt));
+        assertThatEventually(
+                eventListener.getPubSubInfo().queryCompleted().successful().get(),
+                equalTo(expSuccess));
+        assertThatEventually(
+                eventListener.getPubSubInfo().queryCompleted().failure().get(), equalTo(expFail));
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+            textBlock =
+                    """
+      # trackEvent,  pubResult, pubThrow, expAttempt, expSuccess, expFail
+      true,          true,      true,     1,          0,          1
+      true,          true,      false,    1,          1,          0
+      true,          false,     true,     1,          0,          1
+      true,          false,     false,    1,          0,          1
+      false,         true,      true,     0,          0,          0
+      false,         true,      false,    0,          0,          0
+      false,         false,     true,     0,          0,          0
+      false,         false,     false,    0,          0,          0
+      """)
+    void testCounterForSplitCompleted(
+            boolean trackEvent,
+            boolean pubResult,
+            boolean pubThrow,
+            long expAttempt,
+            long expSuccess,
+            long expFail)
+            throws InterruptedException {
+        var publisher = new TestPublisher(pubResult, true, pubThrow);
+        var config =
+                new PubSubEventListenerConfig(
+                        false, false, trackEvent, "", "", null, Encoding.JSON);
+        var eventListener = new PubSubEventListener(config, publisher);
+
+        eventListener.splitCompleted(TestData.FULL_SPLIT_COMPLETED_EVENT);
+
+        assertThatEventually(
+                eventListener.getPubSubInfo().splitCompleted().attempts().get(),
+                equalTo(expAttempt));
+        assertThatEventually(
+                eventListener.getPubSubInfo().splitCompleted().successful().get(),
+                equalTo(expSuccess));
+        assertThatEventually(
+                eventListener.getPubSubInfo().splitCompleted().failure().get(), equalTo(expFail));
+    }
+
+    @Test
+    void testQueryCreatedPublishCorrespondingMessage() {
+        var publisher = new TestPublisher(true, true, false);
+        var config = new PubSubEventListenerConfig(true, true, true, "", "", null, Encoding.JSON);
+        var eventListener = new PubSubEventListener(config, publisher);
+
+        eventListener.queryCreated(TestData.FULL_QUERY_CREATED_EVENT);
+
+        assertThat(publisher.lastPublishedMessage, instanceOf(Schema.QueryCreatedEvent.class));
+    }
+
+    @Test
+    void testQueryCompletedPublishCorrespondingMessage() {
+        var publisher = new TestPublisher(true, true, false);
+        var config = new PubSubEventListenerConfig(true, true, true, "", "", null, Encoding.JSON);
+        var eventListener = new PubSubEventListener(config, publisher);
+
+        eventListener.queryCompleted(TestData.FULL_QUERY_COMPLETED_EVENT);
+
+        assertThat(publisher.lastPublishedMessage, instanceOf(Schema.QueryCompletedEvent.class));
+    }
+
+    @Test
+    void testSplitCompletedPublishCorrespondingMessage() {
+        var publisher = new TestPublisher(true, true, false);
+        var config = new PubSubEventListenerConfig(true, true, true, "", "", null, Encoding.JSON);
+        var eventListener = new PubSubEventListener(config, publisher);
+
+        eventListener.splitCompleted(TestData.FULL_SPLIT_COMPLETED_EVENT);
+
+        assertThat(publisher.lastPublishedMessage, instanceOf(Schema.SplitCompletedEvent.class));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testShutdownNormally(boolean timeout) {
+        var publisher = new TestPublisher(true, timeout, false);
+        var config = new PubSubEventListenerConfig(true, true, true, "", "", null, Encoding.JSON);
+        var eventListener = new PubSubEventListener(config, publisher);
+
+        eventListener.close();
+
+        assertThat(publisher.shutdownCalled, is(true));
+    }
+
+    public static <T> void assertThatEventually(T actual, Matcher<? super T> matcher)
+            throws InterruptedException {
+        int tries = 5;
+        while (--tries > 0 && !matcher.matches(actual)) {
+            Thread.sleep(20);
+        }
+        assertThat(actual, matcher);
+    }
+
+    static class TestPublisher implements Publisher {
+
+        private final boolean pubResult;
+        private final boolean shutdownResult;
+        private final boolean throwExec;
+        private Message lastPublishedMessage;
+        private boolean shutdownCalled;
+
+        TestPublisher(boolean pubResult, boolean shutdownResult, boolean throwExec) {
+            this.pubResult = pubResult;
+            this.shutdownResult = shutdownResult;
+            this.throwExec = throwExec;
+        }
+
+        @Override
+        public CompletableFuture<String> publish(Message message) {
+            this.lastPublishedMessage = message;
+            if (throwExec) {
+                throw new UncheckedIOException("cannot send message", new IOException());
+            }
+            return (pubResult)
+                    ? CompletableFuture.completedFuture("1")
+                    : CompletableFuture.failedFuture(new IOException());
+        }
+
+        @Override
+        public void shutdown() throws InterruptedException {
+            this.shutdownCalled = true;
+            if (shutdownResult) {
+                throw new InterruptedException("timeout");
+            }
+        }
+    }
+}

--- a/plugin/src/test/java/dev/regadas/trino/pubsub/listener/PubSubEventListenerTest.java
+++ b/plugin/src/test/java/dev/regadas/trino/pubsub/listener/PubSubEventListenerTest.java
@@ -52,12 +52,13 @@ class PubSubEventListenerTest {
         eventListener.queryCreated(TestData.FULL_QUERY_CREATED_EVENT);
 
         assertThatEventually(
-                eventListener.getPubSubInfo().queryCreated().attempts().get(), equalTo(expAttempt));
+                eventListener.getPubSubInfo().getQueryCreated().attempts().get(),
+                equalTo(expAttempt));
         assertThatEventually(
-                eventListener.getPubSubInfo().queryCreated().successful().get(),
+                eventListener.getPubSubInfo().getQueryCreated().successful().get(),
                 equalTo(expSuccess));
         assertThatEventually(
-                eventListener.getPubSubInfo().queryCreated().failure().get(), equalTo(expFail));
+                eventListener.getPubSubInfo().getQueryCreated().failure().get(), equalTo(expFail));
     }
 
     @ParameterizedTest
@@ -91,13 +92,14 @@ class PubSubEventListenerTest {
         eventListener.queryCompleted(TestData.FULL_QUERY_COMPLETED_EVENT);
 
         assertThatEventually(
-                eventListener.getPubSubInfo().queryCompleted().attempts().get(),
+                eventListener.getPubSubInfo().getQueryCompleted().attempts().get(),
                 equalTo(expAttempt));
         assertThatEventually(
-                eventListener.getPubSubInfo().queryCompleted().successful().get(),
+                eventListener.getPubSubInfo().getQueryCompleted().successful().get(),
                 equalTo(expSuccess));
         assertThatEventually(
-                eventListener.getPubSubInfo().queryCompleted().failure().get(), equalTo(expFail));
+                eventListener.getPubSubInfo().getQueryCompleted().failure().get(),
+                equalTo(expFail));
     }
 
     @ParameterizedTest
@@ -131,13 +133,14 @@ class PubSubEventListenerTest {
         eventListener.splitCompleted(TestData.FULL_SPLIT_COMPLETED_EVENT);
 
         assertThatEventually(
-                eventListener.getPubSubInfo().splitCompleted().attempts().get(),
+                eventListener.getPubSubInfo().getSplitCompleted().attempts().get(),
                 equalTo(expAttempt));
         assertThatEventually(
-                eventListener.getPubSubInfo().splitCompleted().successful().get(),
+                eventListener.getPubSubInfo().getSplitCompleted().successful().get(),
                 equalTo(expSuccess));
         assertThatEventually(
-                eventListener.getPubSubInfo().splitCompleted().failure().get(), equalTo(expFail));
+                eventListener.getPubSubInfo().getSplitCompleted().failure().get(),
+                equalTo(expFail));
     }
 
     @Test

--- a/plugin/src/test/java/dev/regadas/trino/pubsub/listener/PubSubEventListenerTest.java
+++ b/plugin/src/test/java/dev/regadas/trino/pubsub/listener/PubSubEventListenerTest.java
@@ -220,7 +220,7 @@ class PubSubEventListenerTest {
         }
 
         @Override
-        public void shutdown() throws InterruptedException {
+        public void close() throws InterruptedException {
             this.shutdownCalled = true;
             if (shutdownResult) {
                 throw new InterruptedException("timeout");

--- a/plugin/src/test/java/dev/regadas/trino/pubsub/listener/PubSubEventListenerTest.java
+++ b/plugin/src/test/java/dev/regadas/trino/pubsub/listener/PubSubEventListenerTest.java
@@ -43,8 +43,14 @@ class PubSubEventListenerTest {
             throws InterruptedException {
         var publisher = TestPublisher.from(pubType);
         var config =
-                new PubSubEventListenerConfig(
-                        trackEvent, false, false, "", "", null, Encoding.JSON);
+                PubSubEventListenerConfig.builder()
+                        .trackQueryCreatedEvent(trackEvent)
+                        .trackQueryCompletedEvent(false)
+                        .trackSplitCompletedEvent(false)
+                        .projectId("")
+                        .topicId("")
+                        .encoding(Encoding.JSON)
+                        .build();
         var eventListener = new PubSubEventListener(config, publisher);
 
         eventListener.queryCreated(TestData.FULL_QUERY_CREATED_EVENT);
@@ -76,8 +82,14 @@ class PubSubEventListenerTest {
             throws InterruptedException {
         var publisher = TestPublisher.from(pubType);
         var config =
-                new PubSubEventListenerConfig(
-                        false, trackEvent, false, "", "", null, Encoding.JSON);
+                PubSubEventListenerConfig.builder()
+                        .trackQueryCreatedEvent(false)
+                        .trackQueryCompletedEvent(trackEvent)
+                        .trackSplitCompletedEvent(false)
+                        .projectId("")
+                        .topicId("")
+                        .encoding(Encoding.JSON)
+                        .build();
         var eventListener = new PubSubEventListener(config, publisher);
 
         eventListener.queryCompleted(TestData.FULL_QUERY_COMPLETED_EVENT);
@@ -109,8 +121,14 @@ class PubSubEventListenerTest {
             throws InterruptedException {
         var publisher = TestPublisher.from(pubType);
         var config =
-                new PubSubEventListenerConfig(
-                        false, false, trackEvent, "", "", null, Encoding.JSON);
+                PubSubEventListenerConfig.builder()
+                        .trackQueryCreatedEvent(false)
+                        .trackQueryCompletedEvent(false)
+                        .trackSplitCompletedEvent(trackEvent)
+                        .projectId("")
+                        .topicId("")
+                        .encoding(Encoding.JSON)
+                        .build();
         var eventListener = new PubSubEventListener(config, publisher);
 
         eventListener.splitCompleted(TestData.FULL_SPLIT_COMPLETED_EVENT);


### PR DESCRIPTION
Expose MBean object with counters on attempts, successes, and failures to publish events on PubSub

I tested locally by using `jconsole`
![image](https://github.com/regadas/trino-pubsub-event-listener/assets/7515359/4e19809b-5f00-4bcf-85f8-c8e25671df59)
I also used [jmx prometheus exporter](https://github.com/prometheus/jmx_exporter) to take a look at how it will look like and here is an example.

```
# HELP trino_PubSubEventListener_spotify_trino_QueryCompletedPublicationFailed Attribute exposed for management trino.PubSubEventListener:name=null,type=null,attribute=QueryCompletedPublicationFailed
# TYPE trino_PubSubEventListener_spotify_trino_QueryCompletedPublicationFailed untyped
trino_PubSubEventListener_spotify_trino_QueryCompletedPublicationFailed{topicId="topic",} 0.0
```