### PR TITLE
Fix: preserve field names and omit insignificant whitespace in JSON output

### DIFF
--- a/plugin/src/main/java/dev/regadas/trino/pubsub/listener/Encoder.java
+++ b/plugin/src/main/java/dev/regadas/trino/pubsub/listener/Encoder.java
@@ -30,7 +30,8 @@ public interface Encoder<T> {
 
     @FunctionalInterface
     interface MessageEncoder extends Encoder<Message> {
-        JsonFormat.Printer JSON_PRINTER = JsonFormat.printer();
+        JsonFormat.Printer JSON_PRINTER =
+                JsonFormat.printer().preservingProtoFieldNames().omittingInsignificantWhitespace();
 
         static MessageEncoder create(Encoding encoding) {
             return switch (encoding) {


### PR DESCRIPTION
Fields names are camel case when output is JSON.

Also decrease payload size by omitting significant white space