### PR TITLE
Implement missing fields from QueryIOMetadata

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -16,6 +16,7 @@ dependencies {
 
     def trinoVersion = '419'
     api "io.trino:trino-spi:${trinoVersion}"
+    api "com.fasterxml.jackson.core:jackson-databind:2.15.2"
 
     implementation platform('com.google.cloud:libraries-bom:26.17.0')
     implementation 'com.google.cloud:google-cloud-pubsub'

--- a/plugin/src/main/java/dev/regadas/trino/pubsub/listener/Encoder.java
+++ b/plugin/src/main/java/dev/regadas/trino/pubsub/listener/Encoder.java
@@ -31,7 +31,10 @@ public interface Encoder<T> {
     @FunctionalInterface
     interface MessageEncoder extends Encoder<Message> {
         JsonFormat.Printer JSON_PRINTER =
-                JsonFormat.printer().preservingProtoFieldNames().omittingInsignificantWhitespace();
+                JsonFormat.printer()
+                        .preservingProtoFieldNames()
+                        .omittingInsignificantWhitespace()
+                        .includingDefaultValueFields();
 
         static MessageEncoder create(Encoding encoding) {
             return switch (encoding) {

--- a/plugin/src/main/java/dev/regadas/trino/pubsub/listener/Encoder.java
+++ b/plugin/src/main/java/dev/regadas/trino/pubsub/listener/Encoder.java
@@ -31,10 +31,7 @@ public interface Encoder<T> {
     @FunctionalInterface
     interface MessageEncoder extends Encoder<Message> {
         JsonFormat.Printer JSON_PRINTER =
-                JsonFormat.printer()
-                        .preservingProtoFieldNames()
-                        .omittingInsignificantWhitespace()
-                        .includingDefaultValueFields();
+                JsonFormat.printer().preservingProtoFieldNames().omittingInsignificantWhitespace();
 
         static MessageEncoder create(Encoding encoding) {
             return switch (encoding) {

--- a/plugin/src/main/java/dev/regadas/trino/pubsub/listener/SchemaHelpers.java
+++ b/plugin/src/main/java/dev/regadas/trino/pubsub/listener/SchemaHelpers.java
@@ -1,17 +1,36 @@
 package dev.regadas.trino.pubsub.listener;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.regadas.trino.pubsub.listener.proto.Schema;
 import dev.regadas.trino.pubsub.listener.proto.Schema.TrinoWarning.Code;
 import io.trino.spi.WarningCode;
+import io.trino.spi.eventlistener.ColumnDetail;
+import io.trino.spi.eventlistener.OutputColumnMetadata;
 import io.trino.spi.eventlistener.QueryCompletedEvent;
 import io.trino.spi.eventlistener.QueryContext;
 import io.trino.spi.eventlistener.QueryCreatedEvent;
 import io.trino.spi.eventlistener.QueryFailureInfo;
+import io.trino.spi.eventlistener.QueryIOMetadata;
+import io.trino.spi.eventlistener.QueryInputMetadata;
 import io.trino.spi.eventlistener.QueryMetadata;
+import io.trino.spi.eventlistener.QueryOutputMetadata;
 import io.trino.spi.eventlistener.SplitCompletedEvent;
 import io.trino.spi.eventlistener.SplitFailureInfo;
+import java.util.List;
+import java.util.Optional;
 
 public final class SchemaHelpers {
+
+    private static ObjectMapper mapper = new ObjectMapper();
+
+    static Optional<String> jsonify(java.lang.Object obj) {
+        try {
+            return Optional.of(mapper.writeValueAsString(obj));
+        } catch (JsonProcessingException exc) {
+            return Optional.empty();
+        }
+    }
 
     static Schema.Duration from(java.time.Duration duration) {
         return Schema.Duration.newBuilder()
@@ -53,6 +72,75 @@ public final class SchemaHelpers {
         context.getQueryType().map(Object::toString).ifPresent(contextBuilder::setQueryType);
 
         return contextBuilder.build();
+    }
+
+    static Schema.QueryIOMetadata from(QueryIOMetadata ioMetadata) {
+        var inputs = ioMetadata.getInputs().stream().map(SchemaHelpers::from).toList();
+        var output = ioMetadata.getOutput().map(SchemaHelpers::from);
+        var ioMeta = Schema.QueryIOMetadata.newBuilder().addAllInputs(inputs);
+        output.ifPresent(ioMeta::setOutput);
+        return ioMeta.build();
+    }
+
+    static Schema.QueryInputMetadata from(QueryInputMetadata inputMetadata) {
+        var inputMetadataBuilder =
+                Schema.QueryInputMetadata.newBuilder()
+                        .setCatalogName(inputMetadata.getCatalogName())
+                        .setSchema(inputMetadata.getSchema())
+                        .setTable(inputMetadata.getTable())
+                        .addAllColumns(inputMetadata.getColumns());
+
+        inputMetadata
+                .getConnectorInfo()
+                .flatMap(SchemaHelpers::jsonify)
+                .ifPresent(inputMetadataBuilder::setConnectorInfo);
+
+        jsonify(inputMetadata.getConnectorMetrics())
+                .ifPresent(inputMetadataBuilder::setConnectorMetrics);
+        inputMetadata.getPhysicalInputRows().ifPresent(inputMetadataBuilder::setPhysicalInputRows);
+        inputMetadata
+                .getPhysicalInputBytes()
+                .ifPresent(inputMetadataBuilder::setPhysicalInputBytes);
+
+        return inputMetadataBuilder.build();
+    }
+
+    static Schema.ColumnDetail from(ColumnDetail columnDetail) {
+        return Schema.ColumnDetail.newBuilder()
+                .setCatalog(columnDetail.getCatalog())
+                .setSchema(columnDetail.getSchema())
+                .setTable(columnDetail.getTable())
+                .setColumnName(columnDetail.getColumnName())
+                .build();
+    }
+
+    static Schema.OutputColumnMetadata from(OutputColumnMetadata columnMetadata) {
+        return Schema.OutputColumnMetadata.newBuilder()
+                .setColumnName(columnMetadata.getColumnName())
+                .setColumnType(columnMetadata.getColumnType())
+                .addAllSourceColumns(
+                        columnMetadata.getSourceColumns().stream()
+                                .map(SchemaHelpers::from)
+                                .toList())
+                .build();
+    }
+
+    static Schema.QueryOutputMetadata from(QueryOutputMetadata output) {
+        var outputMetaBuilder =
+                Schema.QueryOutputMetadata.newBuilder()
+                        .setCatalogName(output.getCatalogName())
+                        .setSchema(output.getSchema())
+                        .setTable(output.getTable());
+
+        output.getColumns()
+                .map(List::stream)
+                .map(s -> s.map(SchemaHelpers::from).toList())
+                .ifPresent(outputMetaBuilder::addAllColumns);
+
+        output.getJsonLengthLimitExceeded()
+                .ifPresent(outputMetaBuilder::setJsonLengthLimitExceeded);
+
+        return outputMetaBuilder.build();
     }
 
     static Schema.QueryMetadata from(QueryMetadata metadata) {
@@ -264,6 +352,8 @@ public final class SchemaHelpers {
                                                 .build())
                         .toList();
 
+        var ioMeta = SchemaHelpers.from(event.getIoMetadata());
+
         var builder =
                 Schema.QueryCompletedEvent.newBuilder()
                         .setMetadata(from(event.getMetadata()))
@@ -272,7 +362,8 @@ public final class SchemaHelpers {
                         .setCreateTime(from(event.getCreateTime()))
                         .setExecutionStartTime(from(event.getExecutionStartTime()))
                         .setEndTime(from(event.getEndTime()))
-                        .addAllWarnings(warnings);
+                        .addAllWarnings(warnings)
+                        .setIoMetadata(ioMeta);
         event.getFailureInfo().map(SchemaHelpers::from).ifPresent(builder::setFailureInfo);
 
         return builder.build();

--- a/plugin/src/main/java/dev/regadas/trino/pubsub/listener/SchemaHelpers.java
+++ b/plugin/src/main/java/dev/regadas/trino/pubsub/listener/SchemaHelpers.java
@@ -24,7 +24,7 @@ public final class SchemaHelpers {
 
     private static ObjectMapper mapper = new ObjectMapper();
 
-    static Optional<String> jsonify(java.lang.Object obj) {
+    private static Optional<String> jsonify(Object obj) {
         try {
             return Optional.of(mapper.writeValueAsString(obj));
         } catch (JsonProcessingException exc) {

--- a/plugin/src/main/java/dev/regadas/trino/pubsub/listener/SchemaHelpers.java
+++ b/plugin/src/main/java/dev/regadas/trino/pubsub/listener/SchemaHelpers.java
@@ -19,15 +19,24 @@ import io.trino.spi.eventlistener.SplitCompletedEvent;
 import io.trino.spi.eventlistener.SplitFailureInfo;
 import java.util.List;
 import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public final class SchemaHelpers {
 
     private static ObjectMapper mapper = new ObjectMapper();
+    private static final Logger LOG = Logger.getLogger(SchemaHelpers.class.getPackage().getName());
 
-    private static Optional<String> jsonify(Object obj) {
+    private static Optional<String> jsonify(Object obj, String prop) {
         try {
             return Optional.of(mapper.writeValueAsString(obj));
         } catch (JsonProcessingException exc) {
+            LOG.log(
+                    Level.WARNING,
+                    "Could not serialize property: "
+                            + prop
+                            + " with type: "
+                            + obj.getClass().getCanonicalName());
             return Optional.empty();
         }
     }
@@ -92,10 +101,10 @@ public final class SchemaHelpers {
 
         inputMetadata
                 .getConnectorInfo()
-                .flatMap(SchemaHelpers::jsonify)
+                .flatMap(connInfo -> SchemaHelpers.jsonify(connInfo, "connectorInfo"))
                 .ifPresent(inputMetadataBuilder::setConnectorInfo);
 
-        jsonify(inputMetadata.getConnectorMetrics())
+        jsonify(inputMetadata.getConnectorMetrics(), "connectorMetrics")
                 .ifPresent(inputMetadataBuilder::setConnectorMetrics);
         inputMetadata.getPhysicalInputRows().ifPresent(inputMetadataBuilder::setPhysicalInputRows);
         inputMetadata

--- a/plugin/src/main/proto/schema.proto
+++ b/plugin/src/main/proto/schema.proto
@@ -60,12 +60,8 @@ message ErrorCode {
 }
 
 message QueryIOMetadata {
-  repeated string input_tables = 1;
-  repeated string output_tables = 2;
-  repeated string input_schemas = 3;
-  repeated string output_schemas = 4;
-  repeated string input_catalogs = 5;
-  repeated string output_catalogs = 6;
+  repeated QueryInputMetadata inputs = 1;
+  QueryOutputMetadata output = 2;
 }
 
 message QueryInputMetadata {
@@ -73,7 +69,7 @@ message QueryInputMetadata {
   string schema = 2;
   string table = 3;
   repeated string columns = 4;
-  Any connector_info = 5;
+  string connector_info = 5;
   string connector_metrics = 6;
   int64 physical_input_bytes = 7;
   int64 physical_input_rows = 8;
@@ -83,8 +79,7 @@ message QueryOutputMetadata {
   string catalog_name = 1;
   string schema = 2;
   string table = 3;
-  repeated string columns = 4;
-  repeated OutputColumnMetadata connector_metrics = 5;
+  repeated OutputColumnMetadata columns = 5;
   string connector_output_metadata = 6;
   bool json_length_limit_exceeded = 7;
 }


### PR DESCRIPTION
Implements the dispatch of [`QueryIOMetadata`](https://github.com/trinodb/trino/blob/master/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryIOMetadata.java) and it's [various](https://github.com/trinodb/trino/blob/master/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryInputMetadata.java) [subrecords](https://github.com/trinodb/trino/blob/master/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryOutputMetadata.java).

### Notes:

* The `trino-spi` metadata classes do not derive from protobuf definitions, so unfortunately the `JsonPrinter` used in the `Encoder` can't be repurposed to serialize the nested types.  [They do have Jackson annotation attached, and the spi module exports them](https://trino.io/docs/current/develop/spi-overview.html#building-plugins-via-maven).
  * Pulled in `jackson-databind` to serialize these nested complex fields.
  * Used the [jackson verison from the airlift base pom trino uses.](https://github.com/airlift/airbase/blob/master/airbase/pom.xml#L204)
* Set the Protobuf json printer to `includeDefaultValueFields` in order to provide empty object/array literals where needed for nested values