### PR TITLE
Expose underlying batching settings

### DIFF
--- a/plugin/src/main/java/dev/regadas/trino/pubsub/listener/PubSubEventListener.java
+++ b/plugin/src/main/java/dev/regadas/trino/pubsub/listener/PubSubEventListener.java
@@ -37,7 +37,8 @@ public final class PubSubEventListener implements EventListener, AutoCloseable {
                         config.projectId(),
                         config.topicId(),
                         config.encoding(),
-                        config.credentialsFilePath());
+                        config.credentialsFilePath(),
+                        config.batching());
         return create(config, publisher, stats);
     }
 

--- a/plugin/src/main/java/dev/regadas/trino/pubsub/listener/pubsub/PubSubPublisher.java
+++ b/plugin/src/main/java/dev/regadas/trino/pubsub/listener/pubsub/PubSubPublisher.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutureCallback;
 import com.google.api.core.ApiFutures;
+import com.google.api.gax.batching.BatchingSettings;
 import com.google.api.gax.core.FixedCredentialsProvider;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -34,7 +35,8 @@ public class PubSubPublisher implements Publisher {
             String projectId,
             String topicName,
             Encoding encoding,
-            @Nullable String credentialsFilePath)
+            @Nullable String credentialsFilePath,
+            BatchingSettings batchingSettings)
             throws IOException {
         var credentials =
                 (credentialsFilePath == null)
@@ -45,6 +47,7 @@ public class PubSubPublisher implements Publisher {
                 com.google.cloud.pubsub.v1.Publisher.newBuilder(TopicName.of(projectId, topicName))
                         .setCredentialsProvider(FixedCredentialsProvider.create(credentials))
                         .setEnableCompression(true)
+                        .setBatchingSettings(batchingSettings)
                         .build();
 
         var encoder = MessageEncoder.create(encoding);


### PR DESCRIPTION
Trino events can be quite large and given the limits on Pub/Sub we need to tweak the batching settings to make sure we don't hit the limits.