### PR TITLE
ci: update Java version to 23 in GitHub Actions workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -62,7 +62,7 @@ jobs:
     - uses: actions/setup-java@v4
       with:
         distribution: temurin
-        java-version: 22
+        java-version: 23
 
     - name: Install Protoc
       uses: arduino/setup-protoc@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 22
+          java-version: 23
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3


### PR DESCRIPTION
## Summary
- Update Java version from 22 to 23 in CodeQL and release workflows
- Aligns with project's Java 23 build requirements and nix shell configuration

## Test plan
- [ ] CI workflows pass with Java 23
- [ ] CodeQL analysis completes successfully
- [ ] Release workflow builds correctly