### PR TITLE
deps: update Trino to 476 and Java to 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 23
+          java-version: 24
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -62,7 +62,7 @@ jobs:
     - uses: actions/setup-java@v4
       with:
         distribution: temurin
-        java-version: 23
+        java-version: 24
 
     - name: Install Protoc
       uses: arduino/setup-protoc@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 23
+          java-version: 24
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     compileOnly         "com.google.auto.value:auto-value-annotations:${autoValueVersion}"
     annotationProcessor "com.google.auto.value:auto-value:${autoValueVersion}"
 
-    def trinoVersion = '470'
+    def trinoVersion = '476'
     def jacksonVersion = '2.19.2'
     api "io.trino:trino-spi:${trinoVersion}"
     api "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"

--- a/shell.nix
+++ b/shell.nix
@@ -2,7 +2,7 @@
 
 pkgs.mkShell {
   buildInputs = [
-    (pkgs.gradle.override { java = pkgs.jdk23; })
-    pkgs.jdk23
+    (pkgs.gradle.override { java = pkgs.temurin-bin-24; })
+    pkgs.temurin-bin-24
   ];
 }


### PR DESCRIPTION
## Summary
- Update Trino SPI dependency from 470 to 476
- Update Java version from 23 to 24 across all workflows and development environment
- Align with Trino 476's Java 24 requirement (major version 68)

## Changes
- `plugin/build.gradle`: Trino version 470 → 476
- `.github/workflows/*.yml`: Java 23 → 24
- `shell.nix`: Updated to use temurin-bin-24

## Test plan
- [ ] CI builds pass with Java 24
- [ ] All tests pass with Trino 476
- [ ] Plugin builds and packages correctly